### PR TITLE
Change int to MHD_Result for libmicrohttpd => 0.9.71

### DIFF
--- a/arras4_network/lib/httpserver/HttpServer.cc
+++ b/arras4_network/lib/httpserver/HttpServer.cc
@@ -16,10 +16,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-// microhttpd docs recomend including this after basic types
-// have been defined
-#include <microhttpd.h>
-
 #define HTTP_CONTENT_TYPE "Content-Type"
 
 namespace {
@@ -56,13 +52,13 @@ ResponseState::ResponseState(struct MHD_Connection* aConnection, const char* aUr
 {
 }
 
-int
+MHD_Result
 handleError(struct MHD_Connection* aConnection,
             unsigned int statusCode,
             const std::string& responseMsg,
             enum MHD_ResponseMemoryMode mode)
 {
-    int rtn = MHD_NO;
+    MHD_Result rtn = MHD_NO;
     struct MHD_Response* resp = MHD_create_response_from_buffer(responseMsg.size() + 1,
                                                                 const_cast<char*>(responseMsg.c_str()),
                                                                 mode);
@@ -73,7 +69,7 @@ handleError(struct MHD_Connection* aConnection,
     return rtn;
 }
 
-int
+MHD_Result
 dispatch(
     void* aData,
     struct MHD_Connection* aConnection,
@@ -116,7 +112,7 @@ dispatch(
         return MHD_YES;
     }
 
-    int rtn = MHD_NO;
+    MHD_Result rtn = MHD_NO;
     try {        
         HttpServer* server = static_cast<HttpServer*>(aData);
         ResponseState* state = static_cast<ResponseState*>(*aPtr);
@@ -393,12 +389,12 @@ HttpServer::~HttpServer()
     if (mDaemon) MHD_stop_daemon(mDaemon);
 }
 
-int
+MHD_Result
 HttpServer::_complete(HttpServerResponse& aResp) {
     return aResp.queue();
 }
 
-static int
+static MHD_Result
 key_value_iterator(void* aCls, enum MHD_ValueKind aKind, const char* aKey, const char* aVal)
 {
 

--- a/arras4_network/lib/httpserver/HttpServer.h
+++ b/arras4_network/lib/httpserver/HttpServer.h
@@ -10,8 +10,7 @@
 #include <string>
 #include <thread>
 
-struct MHD_Daemon;
-struct MHD_Connection;
+#include <microhttpd.h>
 
 namespace arras4 {
     namespace network {
@@ -37,7 +36,7 @@ namespace arras4 {
 
             // internal-use only
             void _prepare(HttpServerRequest&, struct MHD_Connection*);
-            int _complete(HttpServerResponse&);
+            MHD_Result _complete(HttpServerResponse&);
 
         private:
             MHD_Daemon* mDaemon;

--- a/arras4_network/lib/httpserver/HttpServerRequest.h
+++ b/arras4_network/lib/httpserver/HttpServerRequest.h
@@ -6,7 +6,7 @@
 
 #include "httpserver_types.h"
 
-struct MHD_Connection;
+#include <microhttpd.h>
 
 namespace arras4 {
     namespace network {

--- a/arras4_network/lib/httpserver/HttpServerResponse.cc
+++ b/arras4_network/lib/httpserver/HttpServerResponse.cc
@@ -4,7 +4,6 @@
 #include "HttpServerResponse.h"
 #include "HttpServerException.h"
 
-#include <microhttpd.h>
 #include <cstring>
 
 #define HTTP_CONTENT_TYPE "Content-Type"
@@ -31,7 +30,7 @@ HttpServerResponse::write(const std::string& aStringData)
 }
 
 
-int
+MHD_Result
 HttpServerResponse::queue()
 {
     struct MHD_Response* response = nullptr;

--- a/arras4_network/lib/httpserver/HttpServerResponse.h
+++ b/arras4_network/lib/httpserver/HttpServerResponse.h
@@ -6,7 +6,7 @@
 
 #include "httpserver_types.h"
 
-struct MHD_Connection;
+#include <microhttpd.h>
 
 namespace arras4 {
     namespace network {
@@ -46,7 +46,7 @@ private:
     std::string mText;
     ServerResponseCode mCode;
 
-    int queue();
+    MHD_Result queue();
 };
 
 }


### PR DESCRIPTION
This fixes build errors for microhttpd versions later than 0.9.71 which changed out their result type from an in to an enum.