### PR TITLE
Let CMake find libcgroup

### DIFF
--- a/arras4_core_impl/lib/execute/CMakeLists.txt
+++ b/arras4_core_impl/lib/execute/CMakeLists.txt
@@ -48,13 +48,23 @@ target_link_libraries(${LibName}
         ${PROJECT_NAME}::chunking
         ${PROJECT_NAME}::core_messages
         ${PROJECT_NAME}::network
-        cgroup
 )
 
 target_include_directories(${LibName}
     PUBLIC
         $<BUILD_INTERFACE:${BuildIncludeDir}>
         $<INSTALL_INTERFACE:include>)
+
+find_path(LIBCGROUP_INCLUDE_DIR
+    NAMES libcgroup.h
+)
+
+find_library(LIBCGROUP_LIBRARY
+    NAMES cgroup
+)
+
+target_include_directories(${LibName} PRIVATE ${LIBCGROUP_INCLUDE_DIR})
+target_link_libraries(${LibName} PRIVATE ${LIBCGROUP_LIBRARY})
 
 # If at Dreamworks add a SConscript stub file so others can use this library.
 SConscript_Stub(${LibName})


### PR DESCRIPTION
Allows libcgroup to be found if it is installed in a non standard location